### PR TITLE
Support opening tabs in the background

### DIFF
--- a/assets/javascript/feedbin_content.js
+++ b/assets/javascript/feedbin_content.js
@@ -1,0 +1,11 @@
+;(function () {
+  "use strict"
+
+  const root = globalThis.browser ?? globalThis.chrome
+
+  root.runtime.onMessage.addListener(function (message, _, sendResponse) {
+    if (message === "open_in_background") {
+      sendResponse(document.getElementById("source_link")?.href)
+    }
+  })
+})()

--- a/assets/javascript/worker.js
+++ b/assets/javascript/worker.js
@@ -1,0 +1,19 @@
+"use strict"
+
+const root = globalThis.browser ?? globalThis.chrome
+
+root.commands.onCommand.addListener(function (name, tab) {
+  if (name === "open_in_background") {
+    root.tabs.sendMessage(tab.id, name).then(function (response) {
+      // At Chrome version 111 we cannot yet use URL.canParse(). Try-catch.
+      try {
+        !!new URL(response) &&
+        root.tabs.create({
+            active: false,
+            openerTabId: tab.id,
+            url: response
+        })
+      } catch (_) {}
+    }, () => {})
+  }
+})

--- a/manifest.yml
+++ b/manifest.yml
@@ -24,6 +24,15 @@ defaults: &defaults
       suggested_key:
         default: Ctrl+Shift+F
         mac: MacCtrl+Shift+F
+    open_in_background:
+      description: Open current article in a background tab
+      suggested_key:
+        default: Alt+V
+  background:
+    service_worker: assets/javascript/worker.js
+  content_scripts:
+  - matches: [https://feedbin.com/*]
+    js: [assets/javascript/feedbin_content.js]
 
 # Safari adds `nativeMessaging` permission to
 # handle authentication with the Feedbin app.
@@ -50,6 +59,8 @@ firefox:
   icons:
     32: assets/images/icon-square-32.png
     64: assets/images/icon-square-64.png
+  background:
+    scripts: [assets/javascript/worker.js]
   browser_specific_settings:
     gecko:
       id: support@feedbin.com


### PR DESCRIPTION
This brings the functionality of the very old [Feedbin Link Opener](https://github.com/feedbin/feedbin-link-opener-chrome) (and [my Firefox port of it](https://github.com/Zegnat/feedbin-link-opener-firefox)) to this new official browser extension.

I have tried to match the general code style of this repository.

The resulting (unpacked) extensions were tested in Firefox 142.0 and Chrome 138 on macOS.

Notes:
1. I do not load the entire browser polyfill into the content script or service worker. The version of the API used is compatible between Firefox and Chrome, so a simple fallback from `browser` to `chrome` is used.
2. We might want to change the `suggested_key` to something better. I had problems running with <kbd>shift</kbd><kbd>v</kbd>, but this substituted version with Alt is not the best either.