### PR TITLE
add another open in background keyboard shortcut

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -29,6 +29,7 @@ defaults: &defaults
       suggested_key:
         default: Ctrl+Shift+V
         mac: MacCtrl+Shift+V
+        linux: Ctrl+Super+V
   background:
     service_worker: assets/javascript/content/worker.js
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -29,7 +29,7 @@ defaults: &defaults
       suggested_key:
         default: Ctrl+Shift+V
         mac: MacCtrl+Shift+V
-        linux: Ctrl+Super+V
+        linux: Ctrl+Shift+U
   background:
     service_worker: assets/javascript/content/worker.js
 


### PR DESCRIPTION
On linux crtl+shift+v doesn't seem to work for me (ubuntu 24.04). I think it is colliding with a system shortcut since that combination is frequently paste on linux.

I'm not sure if crt+super+v will work but figured I would try after taking a look at https://github.com/feedbin/feedbin-extension/pull/1

I am having problems running it to test if this combo works though. The code looks reasonable so I'm not sure what the error is talking about.

```
07:43:23 jekyll.1 |       Generating...
07:43:23 jekyll.1 |   Liquid Exception: undefined local variable or method `it' for #<Views::Index:0x000078ed9c6c3d80 @_state=#<Phlex::SGML::State:0x000078ed9c9cdbc0 @buffer="<!doctype html>", @capturing=false, @user_context={}, @fragments=nil, @fragment_depth=0, @cache_stack=[], @halt_signal=nil, @output_buffer="">> in index.html
07:43:23 jekyll.1 |                     ------------------------------------------------
07:43:23 jekyll.1 |       Jekyll 4.4.1   Please append `--trace` to the `serve` command
07:43:23 jekyll.1 |                      for any additional information or backtrace.
07:43:23 jekyll.1 |                     ------------------------------------------------
07:43:23 jekyll.1 | /var/lib/gems/3.2.0/gems/phlex-2.3.1/lib/phlex/kit.rb:11:in `method_missing': undefined local variable or method `it' for #<Views::Index:0x000078ed9c6c3d80 @_state=#<Phlex::SGML::State:0x000078ed9c9cdbc0 @buffer="<!doctype html>", @capturing=false, @user_context={}, @fragments=nil, @fragment_depth=0, @cache_stack=[], @halt_signal=nil, @output_buffer="">> (NameError)
07:43:23 jekyll.1 | Did you mean?  i
07:43:23 jekyll.1 |     from /home/joe/Source/oss/feedbin-extension/_plugins/component.rb:78:in `block in get_controller'
07:43:23 jekyll.1 |     from /home/joe/Source/oss/feedbin-extension/_plugins/component.rb:78:in `to_h'
07:43:23 jekyll.1 |     from /home/joe/Source/oss/feedbin-extension/_plugins/component.rb:78:in `get_controller'
```

```
$ bundle -v
Bundler version 2.6.7
$ ruby -v
ruby 3.2.3 (2024-01-18 revision 52bb2ac0a6) [x86_64-linux-gnu]
$ gem -v
3.4.20
```