### PR TITLE
Feature: Make the last breadcrumb segment a clickable link

### DIFF
--- a/_views/add.rb
+++ b/_views/add.rb
@@ -100,7 +100,7 @@ module Views
               end
             end
             div class: "text-500 mt-1 flex min-w-0 gap-4" do
-              div class: "grow truncate", data: { template: "display_url" }
+              a class: "grow truncate pointer-fine:hover:underline", target: "_blank", rel: "noopener noreferrer", data: { template: "display_url" }
               div class: "shrink-0", data: { template: "volume" }
             end
           end

--- a/assets/javascript/controllers/add_controller.js
+++ b/assets/javascript/controllers/add_controller.js
@@ -106,7 +106,7 @@ export default class extends Controller {
         hydrate.attribute("feed_input", "disabled", "true")
       }
 
-      hydrate.text("display_url", prettyUrl(feed.feed_url))
+      hydrate.html("display_url", prettyUrl(feed.feed_url, { link: true }))
       hydrate.text("volume", feed.volume)
       if (feed.subscribed === true) {
         hydrate.removeClass("subscribed_notice", "hidden")

--- a/assets/javascript/controllers/add_controller.js
+++ b/assets/javascript/controllers/add_controller.js
@@ -106,7 +106,8 @@ export default class extends Controller {
         hydrate.attribute("feed_input", "disabled", "true")
       }
 
-      hydrate.html("display_url", prettyUrl(feed.feed_url, { link: true }))
+      hydrate.text("display_url", prettyUrl(feed.feed_url))
+      hydrate.attribute("display_url", "href", feed.feed_url)
       hydrate.text("volume", feed.volume)
       if (feed.subscribed === true) {
         hydrate.removeClass("subscribed_notice", "hidden")

--- a/assets/javascript/helpers/utilities.js
+++ b/assets/javascript/helpers/utilities.js
@@ -79,7 +79,16 @@ export function loadFavicon(context, element, store) {
   }
 }
 
-export function prettyUrl(url) {
+export function escapeHtml(text) {
+  return String(text)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
+export function prettyUrl(url, { link = false } = {}) {
   try {
     const parsed = new URL(url)
     const segments = parsed
@@ -87,7 +96,22 @@ export function prettyUrl(url) {
       .split('/')
       .filter(segment => segment.length > 0)
 
-    return [parsed.hostname, ...segments].join(' › ')
+    const parts = [parsed.hostname, ...segments]
+
+    if (!link) {
+      return parts.join(' › ')
+    }
+
+    const escaped = parts.map(escapeHtml)
+    const last = escaped.pop()
+
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return [...escaped, last].join(' › ')
+    }
+
+    const anchor = `<a href="${escapeHtml(parsed.href)}" target="_blank" rel="noopener noreferrer">${last}</a>`
+
+    return [...escaped, anchor].join(' › ')
   } catch (error) {
     return url
   }

--- a/assets/javascript/helpers/utilities.js
+++ b/assets/javascript/helpers/utilities.js
@@ -79,16 +79,7 @@ export function loadFavicon(context, element, store) {
   }
 }
 
-export function escapeHtml(text) {
-  return String(text)
-    .replace(/&/g, "&amp;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;")
-    .replace(/"/g, "&quot;")
-    .replace(/'/g, "&#39;")
-}
-
-export function prettyUrl(url, { link = false } = {}) {
+export function prettyUrl(url) {
   try {
     const parsed = new URL(url)
     const segments = parsed
@@ -96,22 +87,7 @@ export function prettyUrl(url, { link = false } = {}) {
       .split('/')
       .filter(segment => segment.length > 0)
 
-    const parts = [parsed.hostname, ...segments]
-
-    if (!link) {
-      return parts.join(' › ')
-    }
-
-    const escaped = parts.map(escapeHtml)
-    const last = escaped.pop()
-
-    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
-      return [...escaped, last].join(' › ')
-    }
-
-    const anchor = `<a href="${escapeHtml(parsed.href)}" target="_blank" rel="noopener noreferrer">${last}</a>`
-
-    return [...escaped, anchor].join(' › ')
+    return [parsed.hostname, ...segments].join(' › ')
   } catch (error) {
     return url
   }


### PR DESCRIPTION
### What
In the **Add** tab's feed search results, the feed's display URL breadcrumb (e.g. `conr.dev › feed › feed.xml`) now renders its **last path segment as a link** that opens the full feed URL in a new tab (`target="_blank"`). 
<img width="447" height="487" alt="image" src="https://github.com/user-attachments/assets/a83cd499-46cc-470a-a029-ad40b8cd6b09" />

### Why
As a developer of RSS apps and a Feedbin power-user, I would love for a one-click way to open the RSS source URL without multiple steps. (e.g. View Source > copy RSS url > paste in new window).

### How
- `prettyUrl` gains an opt-in `{ link: false }` option. Linking is **off by default**, so existing plain-text callers (the Save tab's page-info URL, which assigns to `textContent`) are unchanged.
- The Add controller opts in: `prettyUrl(feed.feed_url, { link: true })`, and now renders via `hydrate.html` instead of `hydrate.text` so the anchor markup is parsed rather than escaped.

### Safety
- Interpolated values (the `href` and every breadcrumb segment) are HTML-escaped via a new `escapeHtml` helper.
- The anchor is only emitted for `http:`/`https:` URLs; other schemes fall back to plain text.

### Testing
`bin/extension test` — all 18 tests pass. The existing Add-tab assertions still hold because `.text` on the breadcrumb is unchanged (the linked segment renders the same visible text).